### PR TITLE
Fixed missing variable name issue

### DIFF
--- a/Intending/AppDelegate.swift
+++ b/Intending/AppDelegate.swift
@@ -12,8 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func refreshColor() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             let viewController = self.window!.rootViewController!
-            if let
-            = UserDefaults(suiteName: "group.com.intenting")?.string(forKey: "color") {
+            if let colorString = UserDefaults(suiteName: "group.com.intenting")?.string(forKey: "color") {
                 viewController.view.backgroundColor = ViewController.Color(string: colorString).uiColor
             }
             self.refreshColor()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Hacky implementation of custom Siri intents to demo them for the November 2018 iPhone developer group meeting.
+Fork from a simple demo of custom Siri intents. Ask Siri to change the app background color.


### PR DESCRIPTION
Line was, including whitespace:
 if let
            = UserDefaults(suiteName: "group.com.intenting")?.string(forKey: "color") 

Instead of:
if let colorString = UserDefaults(suiteName: "group.com.intenting")?.string(forKey: "color")
